### PR TITLE
Update documentation for tall.setaei.com deployment

### DIFF
--- a/ase-numerology/README.md
+++ b/ase-numerology/README.md
@@ -18,17 +18,25 @@ light/night mode toggle and now exposes an **Admin area** tab for content operat
 
 The easiest path keeps WordPress as the authoring tool while exporting structured JSON for the Angular app to consume.
 
-1. Set the WordPress base URL via `WP_BASE_URL` or pass `--baseUrl=https://yoursite.com` directly.
+1. Set the WordPress base URL via `WP_BASE_URL` or pass `--baseUrl=https://yoursite.com` directly. If no value is
+   provided the tooling falls back to `https://tall.setaei.com`.
 2. Run the export script:
 
    ```bash
-   npm run export:wordpress -- --baseUrl=https://tall.setaei.com
+   npm run export:wordpress
    ```
 
    The script stores JSON snapshots in `src/assets/wordpress` (pages, posts, media and taxonomies) plus a `meta.json`
-   manifest.
+   manifest. Pass a different `--baseUrl=` if you need to export from staging or localhost.
 3. Review the new admin tab inside the UI for mapping guidance and follow-up tasks (wiring HttpClient, scheduling
    automation, etc.).
 
 You can schedule the same command in CI/CD to keep the Angular build synchronized with editors who remain in WordPress.
-The development server runs on [http://localhost:4200](http://localhost:4200). The layout is fully responsive and includes a light/night mode toggle.
+
+## Deployment domain and admin entry points
+
+- **Live Angular bundle:** [https://tall.setaei.com](https://tall.setaei.com)
+- **WordPress admin:** [https://tall.setaei.com/wp-admin](https://tall.setaei.com/wp-admin)
+- **In-app admin area:** switch to the “Admin area” tab in the top navigation once the Angular app loads.
+
+Use the WordPress admin for publishing content, then run the export script to sync JSON into the Angular app. Once the content snapshots land in `src/assets/wordpress`, the admin tab inside the Angular UI walks through the remaining migration tasks.

--- a/ase-numerology/tools/export-wordpress-content.mjs
+++ b/ase-numerology/tools/export-wordpress-content.mjs
@@ -13,11 +13,11 @@ function parseArgs(argv) {
 }
 
 const args = parseArgs(process.argv.slice(2));
-const baseUrl = args.baseUrl || process.env.WP_BASE_URL;
+const DEFAULT_BASE_URL = 'https://tall.setaei.com';
+const baseUrl = args.baseUrl || process.env.WP_BASE_URL || DEFAULT_BASE_URL;
 
-if (!baseUrl) {
-  console.error('❌  Please provide a base WordPress URL via --baseUrl or WP_BASE_URL environment variable.');
-  process.exit(1);
+if (!args.baseUrl && !process.env.WP_BASE_URL) {
+  console.info(`ℹ️  Using default WordPress base URL: ${DEFAULT_BASE_URL}`);
 }
 
 const outputDir = resolve(process.cwd(), args.outDir || 'src/assets/wordpress');


### PR DESCRIPTION
## Summary
- document the tall.setaei.com deployment domain, WordPress admin URL, and how to reach the in-app admin area
- default the WordPress export helper to tall.setaei.com when no explicit base URL is provided

## Testing
- not run (docs and tooling only)


------
https://chatgpt.com/codex/tasks/task_e_68e452be856c8323ac2888656d518122