### PR TITLE
Fix dist path detection in FTPS deploy workflow

### DIFF
--- a/ase-numerology/.github/workflows/build-and-deploy.yml
+++ b/ase-numerology/.github/workflows/build-and-deploy.yml
@@ -24,8 +24,12 @@ jobs:
       - name: Build Angular (prod, base at /)
         run: |
           npx ng build --configuration production --base-href "/" --deploy-url "/"
-          APP=$(jq -r '.defaultProject' angular.json)
-          echo "DIST_DIR=dist/$APP/browser" >> $GITHUB_ENV
+          DIST_ROOT=$(jq -r '.projects | to_entries[0].value.architect.build.options.outputPath // empty' angular.json)
+          if [ -z "$DIST_ROOT" ]; then
+            APP_NAME=$(jq -r '.projects | keys[0]' angular.json)
+            DIST_ROOT="dist/$APP_NAME"
+          fi
+          echo "DIST_DIR=${DIST_ROOT%/}/browser" >> $GITHUB_ENV
 
       # FTPS deploy: synker innholdet i dist-folderen til subdomene-roten
       - name: Deploy via FTPS


### PR DESCRIPTION
## Summary
- derive the Angular build output directory from the first project entry instead of the missing defaultProject setting
- fall back to the project name when outputPath is unavailable so the deploy step always has a valid dist path

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e5bc90a6a483239d051c896177ed77