### PR TITLE
Fix karma configuration to use CommonJS

### DIFF
--- a/ase-numerology/karma.conf.js
+++ b/ase-numerology/karma.conf.js
@@ -1,8 +1,7 @@
-import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { constants } from 'karma';
+const { join } = require('node:path');
+const { constants } = require('karma');
 
-export default function (config) {
+module.exports = function (config) {
   config.set({
     basePath: '',
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
@@ -21,7 +20,7 @@ export default function (config) {
       suppressAll: true
     },
     coverageReporter: {
-      dir: join(fileURLToPath(new URL('.', import.meta.url)), './coverage'),
+      dir: join(__dirname, './coverage'),
       subdir: '.',
       reporters: [{ type: 'html' }, { type: 'text-summary' }]
     },
@@ -34,4 +33,4 @@ export default function (config) {
     autoWatch: true,
     singleRun: false
   });
-}
+};


### PR DESCRIPTION
## Summary
- convert karma.conf.js back to CommonJS syntax so Karma can be required under the current package setup
- use __dirname for the coverage directory instead of import.meta URL helpers

## Testing
- node -p "typeof require('./karma.conf.js')" *(fails: package.json in the repo is invalid JSON, preventing Node from loading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e5bc95a6f483239111d96a6d80f549